### PR TITLE
Put back `spring-boot-starter-web` dependency for the non-streaming endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Please verify that:

- [x] `mvn clean install` run
- [x] You have successfully built and run unit tests locally
- [ ] There are new or updated unit tests validating the changes

### :pencil: Description

Put back `spring-boot-starter-web` dependency for the non-streaming endpoint.